### PR TITLE
chore: Fix dependencies configuration for uv

### DIFF
--- a/examples/echo/uv.lock
+++ b/examples/echo/uv.lock
@@ -240,15 +240,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
-    { name = "isort", marker = "extra == 'dev'", specifier = ">=5.0.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
 ]
@@ -256,13 +250,19 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.7.0" },
     { name = "black", specifier = ">=25.1.0" },
+    { name = "build", specifier = ">=0.10.0" },
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "isort", specifier = ">=5.0.0" },
     { name = "mypy", specifier = ">=1.17.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "ruff", specifier = ">=0.12.10" },
+    { name = "safety", specifier = ">=2.0.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250822" },
     { name = "types-requests", specifier = ">=2.31.0" },
 ]

--- a/orchael-sdk/pyproject.toml
+++ b/orchael-sdk/pyproject.toml
@@ -29,19 +29,6 @@ dependencies = [
     "uvicorn[standard]>=0.24.0"
 ]
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-    "black>=23.0.0",
-    "isort>=5.0.0",
-    "mypy>=1.0.0",
-    "ruff>=0.1.0",
-    "safety>=2.0.0",
-    "bandit>=1.7.0",
-    "build>=0.10.0"
-]
-
 [project.scripts]
 orchael-sdk-cli = "orchael_sdk.cli:main"
 orchael-sdk-server = "orchael_sdk.cli:server"
@@ -116,4 +103,7 @@ dev = [
     "safety>=2.0.0",
     "bandit>=1.7.0",
     "build>=0.10.0",
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "isort>=5.0.0"
 ]

--- a/orchael-sdk/uv.lock
+++ b/orchael-sdk/uv.lock
@@ -564,7 +564,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -783,25 +783,13 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
-[package.optional-dependencies]
-dev = [
-    { name = "bandit" },
-    { name = "black" },
-    { name = "build" },
-    { name = "isort" },
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-    { name = "safety" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "bandit" },
     { name = "black" },
     { name = "build" },
     { name = "httpx" },
+    { name = "isort" },
     { name = "mypy" },
     { name = "pydantic" },
     { name = "pytest" },
@@ -814,18 +802,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "build", marker = "extra == 'dev'", specifier = ">=0.10.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
-    { name = "isort", marker = "extra == 'dev'", specifier = ">=5.0.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "safety", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
 ]
@@ -837,9 +816,12 @@ dev = [
     { name = "black", specifier = ">=25.1.0" },
     { name = "build", specifier = ">=0.10.0" },
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "isort", specifier = ">=5.0.0" },
     { name = "mypy", specifier = ">=1.17.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "ruff", specifier = ">=0.12.10" },
     { name = "safety", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

This PR fixes the dependency configuration in the pyproject.toml file to properly work with the `uv` package manager.

## Changes

- **Removed** `[project.optional-dependencies]` section from pyproject.toml
- **Moved** development dependencies to `[tool.uv.dev-dependencies]` section
- **Updated** uv.lock files to reflect the new dependency structure

## Rationale

The `uv` package manager uses `[tool.uv.dev-dependencies]` instead of `[project.optional-dependencies]` for development dependencies. This change ensures that:

1. Development dependencies are properly recognized by uv
2. The project follows uv best practices
3. Lock files are correctly generated and maintained

## Testing

- [x] Dependencies resolve correctly with uv
- [x] Development tools (pytest, black, ruff, etc.) are available
- [x] Lock files are properly updated

## Related

Fixes dependency management issues when using uv as the package manager.